### PR TITLE
feat: add workflow

### DIFF
--- a/.github/workflows/deploy-info-comment-on-pr.yml
+++ b/.github/workflows/deploy-info-comment-on-pr.yml
@@ -1,0 +1,120 @@
+name: Deployment Info Comment on PR
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  get-latest-commit:
+    concurrency:
+      group: ${{ github.head_ref }}
+      cancel-in-progress: false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+
+      - name: Get Latest Commit Hash
+        id: get_commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          COMMIT_HASH=$(gh pr view ${{ github.event.pull_request.number }} --json commits -q ".commits[-1].oid")
+          echo "COMMIT_HASH=${COMMIT_HASH}" >> $GITHUB_ENV
+          SHORT_COMMIT_HASH=${COMMIT_HASH:0:7}
+          echo "SHORT_COMMIT_HASH=${SHORT_COMMIT_HASH}" >> $GITHUB_ENV
+
+      - name: Output Latest Commit Hash
+        run: echo "Latest Commit Hash ... ${{ env.COMMIT_HASH }}"
+
+      - name: Fetch latest deployment info and match with commit hash
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_PROJECT_NAME: ${{ secrets.CLOUDFLARE_PROJECT_NAME }}
+        run: |
+          response=$(curl -s -X GET "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$CLOUDFLARE_PROJECT_NAME/deployments" \
+            -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+            -H "Content-Type: application/json")
+
+          # COMMIT_HASHと一致するデプロイメントを検索
+          matching_deployment=$(echo "$response" | jq -r --arg commit "${{ env.COMMIT_HASH }}" '.result[] | select(.deployment_trigger.metadata.commit_hash == $commit)')
+
+          if [ -z "$matching_deployment" ]; then
+            echo "No deployment found for the latest commit hash."
+            exit 1
+          fi
+
+          # 一致するデプロイメントからURL、エイリアス、IDを取得
+          deployment_url=$(echo "$matching_deployment" | jq -r '.url')
+          deployment_alias_url=$(echo "$matching_deployment" | jq -r '.aliases[0]')
+          pages_deployment_id=$(echo "$matching_deployment" | jq -r '.id')
+
+          echo "Matched Deploy URL: $deployment_url"
+          echo "Deploy Alias URL: $deployment_alias_url"
+          echo "Deploy ID: $pages_deployment_id"
+
+          # 必要であればGitHub Actionsの環境変数に保存
+          echo "LATEST_DEPLOY_URL=$deployment_url" >> $GITHUB_ENV
+          echo "DEPLOY_ALIAS_URL=$deployment_alias_url" >> $GITHUB_ENV
+          echo "DEPLOY_ID=$pages_deployment_id" >> $GITHUB_ENV
+
+      - name: Create Comment Content
+        run: |
+          {
+            echo "GH_SAMPLE_COMMENT<<EOF"
+            echo "<!-- DEPLOYMENT_COMMENT -->"
+            echo "## Deploying ${{ secrets.CLOUDFLARE_PROJECT_NAME }} with &nbsp;<a href='https://pages.dev'><img alt='Cloudflare Pages' src='https://user-images.githubusercontent.com/23264/106598434-9e719e00-654f-11eb-9e59-6167043cfa01.png' width='16'></a> &nbsp;Cloudflare Pages"
+            echo ""
+            echo "<table><tr><td><strong>Latest commit:</strong> </td><td>"
+            echo "<code>${{ env.SHORT_COMMIT_HASH }}</code>"
+            echo "</td></tr>"
+            echo "<tr><td><strong>Status:</strong></td><td>&nbsp;🔥&nbsp; Deploy successful!</td></tr>"
+            echo "<tr><td><strong>Preview URL:</strong></td><td>"
+            echo "<a href='${{ env.LATEST_DEPLOY_URL }}'>${{ env.LATEST_DEPLOY_URL }}</a>"
+            echo "</td></tr>"
+            echo "<tr><td><strong>Branch Preview URL:</strong></td><td>"
+            echo "<a href='${{ env.DEPLOY_ALIAS_URL }}'>${{ env.DEPLOY_ALIAS_URL }}</a>"
+            echo "</td></tr>"
+            echo "</table>"
+            echo ""
+            echo "[View logs](https://dash.cloudflare.com/?to=/:account/pages/view/${{ secrets.CLOUDFLARE_PROJECT_NAME }}/${{ env.DEPLOY_ID }})"
+            echo "EOF"
+          } >> "$GITHUB_ENV"
+
+      - name: Add or Update Comment on Pull Request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+
+          # Fetch existing comments
+          COMMENTS=$(gh api repos/${{ github.repository }}/issues/${PR_NUMBER}/comments --jq '.[] | @base64')
+
+          COMMENT_ID=""
+
+          for COMMENT in $COMMENTS; do
+            COMMENT_JSON=$(echo $COMMENT | base64 --decode)
+            BODY=$(echo $COMMENT_JSON | jq -r '.body')
+            ID=$(echo $COMMENT_JSON | jq -r '.id')
+
+            if echo "$BODY" | grep -q '<!-- DEPLOYMENT_COMMENT -->'; then
+              COMMENT_ID=$ID
+              break
+            fi
+          done
+
+          if [ -n "$COMMENT_ID" ]; then
+            echo "Updating existing comment ID: $COMMENT_ID"
+            gh api \
+              --method PATCH \
+              -H "Accept: application/vnd.github.v3+json" \
+              /repos/${{ github.repository }}/issues/comments/$COMMENT_ID \
+              -f body="${{ env.GH_SAMPLE_COMMENT }}"
+          else
+            echo "Creating new comment"
+            gh pr comment $PR_NUMBER --body "${{ env.GH_SAMPLE_COMMENT }}"
+          fi
+
+      - name: Add to Job Summaries
+        run: echo "${{ env.GH_SAMPLE_COMMENT }}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-to-cloudflare.yml
+++ b/.github/workflows/deploy-to-cloudflare.yml
@@ -1,0 +1,107 @@
+name: Deploy to Cloudflare Pages
+
+on:
+  push:
+
+jobs:
+  deploy:
+    concurrency:
+      group: ${{ github.ref_name }}
+      cancel-in-progress: false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Get Latest Commit Hash
+        id: get_commit
+        run: echo "COMMIT_HASH=$(git rev-parse --short=7 HEAD)" >> $GITHUB_ENV
+
+      - name: Setup Bun Environment
+        uses: oven-sh/setup-bun@v2.0.1
+
+      - name: Install Project Dependencies
+        run: bun i
+
+      - name: Build Project with Bun
+        run: bunx @cloudflare/next-on-pages
+
+      - name: Deploy to Cloudflare Pages with Wrangler
+        id: deploy
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy .vercel/output/static --project-name=${{ secrets.CLOUDFLARE_PROJECT_NAME }}
+
+      - name: Create Comment Content
+        run: |
+          {
+            echo "GH_SAMPLE_COMMENT<<EOF"
+            echo "<!-- DEPLOYMENT_COMMENT -->"
+            echo "## Deploying ${{ secrets.CLOUDFLARE_PROJECT_NAME }} with &nbsp;<a href='https://pages.dev'><img alt='Cloudflare Pages' src='https://user-images.githubusercontent.com/23264/106598434-9e719e00-654f-11eb-9e59-6167043cfa01.png' width='16'></a> &nbsp;Cloudflare Pages"
+            echo ""
+            echo "<table><tr><td><strong>Latest commit:</strong> </td><td>"
+            echo "<code>${{ env.COMMIT_HASH }}</code>"
+            echo "</td></tr>"
+            echo "<tr><td><strong>Status:</strong></td><td>&nbsp;🔥&nbsp; Deploy successful!</td></tr>"
+            echo "<tr><td><strong>Preview URL:</strong></td><td>"
+            echo "<a href='${{ steps.deploy.outputs.deployment-url }}'>${{ steps.deploy.outputs.deployment-url }}</a>"
+            echo "</td></tr>"
+            echo "<tr><td><strong>Branch Preview URL:</strong></td><td>"
+            echo "<a href='${{ steps.deploy.outputs.deployment-alias-url }}'>${{ steps.deploy.outputs.deployment-alias-url }}</a>"
+            echo "</td></tr>"
+            echo "</table>"
+            echo ""
+            echo "[View logs](https://dash.cloudflare.com/?to=/:account/pages/view/${{ secrets.CLOUDFLARE_PROJECT_NAME }}/${{ steps.deploy.outputs.pages-deployment-id }})"
+            echo "EOF"
+          } >> "$GITHUB_ENV"
+
+      - name: Check if PR exists
+        id: check_pr
+        run: |
+          if gh pr list --head "${{ github.ref_name }}" --json number --jq '. | length' | grep -q '1'; then
+            echo "PR_EXISTS=true" >> $GITHUB_ENV
+          else
+            echo "PR_EXISTS=false" >> $GITHUB_ENV
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Add or Update Comment on Pull Request
+        if: env.PR_EXISTS == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER=$(gh pr list --head "${{ github.ref_name }}" --json number -q '.[0].number')
+
+          # Fetch existing comments
+          COMMENTS=$(gh api repos/${{ github.repository }}/issues/${PR_NUMBER}/comments --jq '.[] | @base64')
+
+          COMMENT_ID=""
+
+          for COMMENT in $COMMENTS; do
+            COMMENT_JSON=$(echo $COMMENT | base64 --decode)
+            BODY=$(echo $COMMENT_JSON | jq -r '.body')
+            ID=$(echo $COMMENT_JSON | jq -r '.id')
+
+            if echo "$BODY" | grep -q '<!-- DEPLOYMENT_COMMENT -->'; then
+              COMMENT_ID=$ID
+              break
+            fi
+          done
+
+          if [ -n "$COMMENT_ID" ]; then
+            echo "Updating existing comment ID: $COMMENT_ID"
+            gh api \
+              --method PATCH \
+              -H "Accept: application/vnd.github.v3+json" \
+              /repos/${{ github.repository }}/issues/comments/$COMMENT_ID \
+              -f body="${{ env.GH_SAMPLE_COMMENT }}"
+          else
+            echo "Creating new comment"
+            gh pr comment $PR_NUMBER --body "${{ env.GH_SAMPLE_COMMENT }}"
+          fi
+
+      - name: Add to Job Summaries
+        run: echo "${{ env.GH_SAMPLE_COMMENT }}" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
#### feat: Cloudflare Pagesのデプロイとコメントのワークフローを追加
- `push`イベントでデプロイをトリガーするワークフローを追加し、PRが存在する場合はデプロイの詳細をプルリクエストのコメントに投稿
- PRがオープンされた場合は、デプロイの詳細をコメントとして投稿するワークフローを追加
-`push`トリガーのワークフローがすでに進行中の場合は、そのワークフローが完了した後にPRコメントのワークフローを開始するように設定し正確なデプロイの詳細を取得
- 重複を防ぐために、既存のデプロイ情報のコメントを上書きする形でコメントを更新する機能を実装

> [!CAUTION]
> 待機するんじゃなくて実行やめちゃえば良くないか??
やるなら終了の検知タイミングをもう少し厳格にデプロイ終了までで線引いたほうがいい
あと絵文字は、🔥 より ✅ の方が色彩バランス的にいい
>
> どっちがいいか分からないから別PRにする
